### PR TITLE
Fix usage of PyPlot

### DIFF
--- a/src/BivariateCopulas.jl
+++ b/src/BivariateCopulas.jl
@@ -40,9 +40,9 @@ include("NormalDistribution.jl")
 function __init__()
     @require PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0" begin
         @require PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee" begin
-            using PyCall
-            using PyPlot
-            import PyPlot: plot
+            using .PyCall
+            using .PyPlot
+            import .PyPlot: plot
             include("plotting.jl")
             return using3D()
         end


### PR DESCRIPTION
Without that I get this error:

```julia
┌ Warning: Error requiring `PyPlot` from `BivariateCopulas`
│   exception =
│    ArgumentError: Package BivariateCopulas does not have PyCall in its dependencies:
│    - You may have a partially installed environment. Try `Pkg.instantiate()`
│      to ensure all packages in the environment are installed.
│    - Or, if you have BivariateCopulas checked out for development and have
│      added PyCall as a dependency but haven't updated your primary
│      environment's manifest file, try `Pkg.resolve()`.
│    - Otherwise you may need to report an issue with BivariateCopulas
```