### PR TITLE
Add Frank copula

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         julia-version:
           - "1.6"
-          - "1.7"
+          - "1.8"
         os:
           - "ubuntu-latest"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         julia-version:
           - "1.6"
-          - "1.8"
+          - "1.9"
         os:
           - "ubuntu-latest"
     steps:

--- a/Project.toml
+++ b/Project.toml
@@ -5,14 +5,18 @@ version = "0.1.4"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+GSL = "92c85e6c-cbff-5e0c-80f7-495c94daaecd"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 
 [compat]
 Distributions = "0.24, 0.25"
+GSL = "1.0.1"
 Interpolations = "0.13"
 Reexport = "1.0"
 Requires = "1.2.0, 1.3.0"
+Roots = "2.0.8"
 julia = "1"

--- a/src/BivariateCopulas.jl
+++ b/src/BivariateCopulas.jl
@@ -17,6 +17,8 @@ using Requires
 @reexport using Distributions             #   https://github.com/JuliaStats/Distributions.jl
 using LinearAlgebra                       #   Main Library
 using Interpolations                      #   https://github.com/JuliaMath/Interpolations.jl
+using GSL # for debye function
+using Roots
 
 import Distributions: cdf, quantile, rand
 

--- a/src/archimedean/archimedean.jl
+++ b/src/archimedean/archimedean.jl
@@ -20,6 +20,9 @@ function cdf(c::ArchimedeanCopula, u1::Real, u2::Real)
 end
 
 function density(c::ArchimedeanCopula, u1::Real, u2::Real)
+    if iszero(u1) || iszero(u2)
+        return zero(u1)
+    end
     return D²φ(φ⁻¹(u1, c) + φ⁻¹(u2, c), c) * D¹φ⁻¹(u1, c) * D¹φ⁻¹(u2, c)
 end
 

--- a/src/archimedean/archimedean.jl
+++ b/src/archimedean/archimedean.jl
@@ -4,7 +4,7 @@ function rosenblatt(M::AbstractMatrix, c::ArchimedeanCopula)
     u1 = M[:, 1]
     u2 = M[:, 2]
 
-    return [u1 (φ¹.(φ⁻¹.(u1, c) + φ⁻¹.(u2, c), c) ./ φ¹.(φ⁻¹.(u1, c), c))]
+    return [u1 (D¹φ.(φ⁻¹.(u1, c) + φ⁻¹.(u2, c), c) ./ D¹φ.(φ⁻¹.(u1, c), c))]
 end
 
 function inverse_rosenblatt(U::AbstractMatrix, c::ArchimedeanCopula)
@@ -20,7 +20,7 @@ function cdf(c::ArchimedeanCopula, u1::Real, u2::Real)
 end
 
 function density(c::ArchimedeanCopula, u1::Real, u2::Real)
-    return φ²(φ⁻¹(u1, c) + φ⁻¹(u2, c), c) * ∇φ⁻¹(u1, c) * ∇φ⁻¹(u2, c)
+    return D²φ(φ⁻¹(u1, c) + φ⁻¹(u2, c), c) * D¹φ⁻¹(u1, c) * D¹φ⁻¹(u2, c)
 end
 
 function sample(c::ArchimedeanCopula, n::Int64)

--- a/src/archimedean/archimedean.jl
+++ b/src/archimedean/archimedean.jl
@@ -4,7 +4,15 @@ function rosenblatt(M::AbstractMatrix, c::ArchimedeanCopula)
     u1 = M[:, 1]
     u2 = M[:, 2]
 
-    return [u1 (φ².(φ⁻¹.(u1, c) + φ⁻¹.(u2, c), c) ./ φ².(φ⁻¹.(u1, c), c))]
+    return [u1 (φ¹.(φ⁻¹.(u1, c) + φ⁻¹.(u2, c), c) ./ φ¹.(φ⁻¹.(u1, c), c))]
+end
+
+function inverse_rosenblatt(U::AbstractMatrix, c::ArchimedeanCopula)
+    u2 = map(eachrow(U)) do u
+        return find_zero(x -> rosenblatt([u[1] x], c)[2] - u[2], (0, 1), Roots.A42())
+    end
+
+    return [U[:, 1] u2]
 end
 
 function cdf(c::ArchimedeanCopula, u1::Real, u2::Real)
@@ -29,3 +37,4 @@ end
 
 include("independence.jl")
 include("clayton.jl")
+include("frank.jl")

--- a/src/archimedean/clayton.jl
+++ b/src/archimedean/clayton.jl
@@ -2,7 +2,7 @@ struct Clayton <: ArchimedeanCopula
     ϑ::Real
 
     function Clayton(ϑ::Real)
-        # bivariate clayton can go as low as -1
+        # bivariate clayton is defined on ϑ ∈ (0, ∞)
         @assert 0 <= ϑ <= Inf
 
         if ϑ == 0.0

--- a/src/archimedean/clayton.jl
+++ b/src/archimedean/clayton.jl
@@ -3,7 +3,7 @@ struct Clayton <: ArchimedeanCopula
 
     function Clayton(ϑ::Real)
         # bivariate clayton can go as low as -1
-        @assert -1 <= ϑ <= Inf
+        @assert 0 <= ϑ <= Inf
 
         if ϑ == 0.0
             @warn "Clayton returns an independence copula for ϑ == 0.0"
@@ -33,7 +33,7 @@ First derivative of the Clayton copula generator.
 """
 function D¹φ(x::Real, c::Clayton)
     α = 1 / c.ϑ
-    return -α * (1 + x)^(-(1 + α))
+    return -α * (1 + x)^(-1 - α)
 end
 
 """
@@ -43,8 +43,7 @@ Second derivative of the Clayton copula generator.
 """
 function D²φ(x::Real, c::Clayton)
     α = 1 / c.ϑ
-    β = α * (1 + α)
-    return β * (x + 1)^(-(2 + α))
+    return (α + α^2) * (1 + x)^(-2 - α)
 end
 
 """

--- a/src/archimedean/clayton.jl
+++ b/src/archimedean/clayton.jl
@@ -3,9 +3,12 @@ struct Clayton <: ArchimedeanCopula
 
     function Clayton(ϑ::Real)
         # bivariate clayton is defined on ϑ ∈ (0, ∞)
-        @assert 0 <= ϑ <= Inf
+        @assert -1 <= ϑ <= Inf
 
-        if ϑ == 0.0
+        if ϑ == -1
+            @warn "Clayton returns a W copula for ϑ == -1"
+            return W()
+        elseif ϑ == 0.0
             @warn "Clayton returns an independence copula for ϑ == 0.0"
             return Independence()
         elseif ϑ == Inf
@@ -24,6 +27,15 @@ Generator of the Clayton copula.
 """
 function φ(x::Real, c::Clayton)
     return (1 + x)^(-1 / c.ϑ)
+end
+
+"""
+    φ⁻¹(x::Real, c::Clayton)
+
+Inverse generator of the Clayton copula.
+"""
+function φ⁻¹(x::Real, c::Clayton)
+    return x^(-c.ϑ) - 1
 end
 
 """
@@ -47,21 +59,19 @@ function D²φ(x::Real, c::Clayton)
 end
 
 """
-    φ⁻¹(x::Real, c::Clayton)
-
-Inverse generator of the Clayton copula.
-"""
-function φ⁻¹(x::Real, c::Clayton)
-    return x^(-c.ϑ) - 1
-end
-
-"""
     D¹φ⁻¹(x::Real, c::Clayton)
 
 First derivative of the Clayton copula inverse generator.
 """
 function D¹φ⁻¹(x::Real, c::Clayton)
     return -c.ϑ * x^(-c.ϑ - 1)
+end
+
+function cdf(c::Clayton, u1::Real, u2::Real)
+    if c.ϑ < 0 && (u1^(-c.ϑ) + u2^(-c.ϑ) - 1) < 0
+        return 0
+    end
+    return (u1^(-c.ϑ) + u2^(-c.ϑ) - 1)^(-1 / c.ϑ)
 end
 
 function rosenblatt(M::AbstractMatrix, c::Clayton)

--- a/src/archimedean/clayton.jl
+++ b/src/archimedean/clayton.jl
@@ -5,10 +5,7 @@ struct Clayton <: ArchimedeanCopula
         # bivariate clayton can go as low as -1
         @assert -1 <= ϑ <= Inf
 
-        if ϑ < -0.5
-            @warn "Clayton returns a W copula for ϑ < -0.5"
-            return W()
-        elseif ϑ == 0.0
+        if ϑ == 0.0
             @warn "Clayton returns an independence copula for ϑ == 0.0"
             return Independence()
         elseif ϑ == Inf
@@ -26,6 +23,11 @@ end
 
 function φ⁻¹(x::Real, c::Clayton)
     return x^(-c.ϑ) - 1
+end
+
+function φ¹(x::Real, c::Clayton)
+    α = 1 / c.ϑ
+    return -α * (1 + x)^(-(1 + α))
 end
 
 function φ²(x::Real, c::Clayton)

--- a/src/archimedean/clayton.jl
+++ b/src/archimedean/clayton.jl
@@ -17,26 +17,51 @@ struct Clayton <: ArchimedeanCopula
     end
 end
 
+"""
+    φ(x::Real, c::Clayton)
+
+Generator of the Clayton copula.
+"""
 function φ(x::Real, c::Clayton)
     return (1 + x)^(-1 / c.ϑ)
 end
 
-function φ⁻¹(x::Real, c::Clayton)
-    return x^(-c.ϑ) - 1
-end
+"""
+    D¹φ(x::Real, c::Clayton)
 
-function φ¹(x::Real, c::Clayton)
+First derivative of the Clayton copula generator.
+"""
+function D¹φ(x::Real, c::Clayton)
     α = 1 / c.ϑ
     return -α * (1 + x)^(-(1 + α))
 end
 
-function φ²(x::Real, c::Clayton)
+"""
+    D²φ(x::Real, c::Clayton)
+
+Second derivative of the Clayton copula generator.
+"""
+function D²φ(x::Real, c::Clayton)
     α = 1 / c.ϑ
     β = α * (1 + α)
     return β * (x + 1)^(-(2 + α))
 end
 
-function ∇φ⁻¹(x::Real, c::Clayton)
+"""
+    φ⁻¹(x::Real, c::Clayton)
+
+Inverse generator of the Clayton copula.
+"""
+function φ⁻¹(x::Real, c::Clayton)
+    return x^(-c.ϑ) - 1
+end
+
+"""
+    D¹φ⁻¹(x::Real, c::Clayton)
+
+First derivative of the Clayton copula inverse generator.
+"""
+function D¹φ⁻¹(x::Real, c::Clayton)
     return -c.ϑ * x^(-c.ϑ - 1)
 end
 

--- a/src/archimedean/clayton.jl
+++ b/src/archimedean/clayton.jl
@@ -26,6 +26,9 @@ end
 Generator of the Clayton copula.
 """
 function φ(x::Real, c::Clayton)
+    if x > floatmax()
+        return 0.0
+    end
     return (1 + x)^(-1 / c.ϑ)
 end
 
@@ -69,9 +72,18 @@ end
 
 function cdf(c::Clayton, u1::Real, u2::Real)
     if c.ϑ < 0 && (u1^(-c.ϑ) + u2^(-c.ϑ) - 1) < 0
-        return 0
+        return zero(u1)
     end
     return (u1^(-c.ϑ) + u2^(-c.ϑ) - 1)^(-1 / c.ϑ)
+end
+
+function density(c::Clayton, u1::Real, u2::Real)
+    if iszero(u1) || iszero(u2) || (c.ϑ < 0 && (u1^(-c.ϑ) + u2^(-c.ϑ) - 1) < 0)
+        return zero(u1)
+    end
+    α = 1 / c.ϑ
+    t = φ⁻¹(u1, c) + φ⁻¹(u2, c)
+    return (c.ϑ + 1) * (u1 * u2)^(-(1 + c.ϑ)) * (1 + t)^(-(2 + α))
 end
 
 function rosenblatt(M::AbstractMatrix, c::Clayton)

--- a/src/archimedean/frank.jl
+++ b/src/archimedean/frank.jl
@@ -14,25 +14,50 @@ struct Frank <: ArchimedeanCopula
     end
 end
 
+"""
+    φ(x::Real, c::Frank)
+
+Generator of the Frank copula.
+"""
 function φ(x::Real, c::Frank)
     return -1 / c.ϑ * log(exp(-x) * (exp(-c.ϑ) - 1) + 1)
 end
 
-function φ⁻¹(x::Real, c::Frank)
-    return -log((exp(-c.ϑ * x) - 1) / (exp(-c.ϑ) - 1))
-end
+"""
+    D¹φ(x::Real, c::Frank)
 
-function φ¹(x::Real, c::Frank)
+First derivative of the Frank copula generator.
+"""
+function D¹φ(x::Real, c::Frank)
     z = (1 - exp(-c.ϑ)) * exp(-x)
     return -(1 / c.ϑ) * z / (1 - z)
 end
 
-function φ²(x::Real, c::Frank)
+"""
+    D²φ(x::Real, c::Frank)
+
+Second derivative of the Frank copula generator.
+"""
+function D²φ(x::Real, c::Frank)
     z = (1 - exp(-c.ϑ)) * exp(-x)
     return (1 / c.ϑ) * z / (1 - z)^2
 end
 
-function ∇φ⁻¹(x::Real, c::Frank)
+"""
+    φ⁻¹(x::Real, c::Frank)
+
+Inverse generator of the Frank copula.
+"""
+function φ⁻¹(x::Real, c::Frank)
+    return -log((exp(-c.ϑ * x) - 1) / (exp(-c.ϑ) - 1))
+end
+
+"""
+    D¹φ⁻¹(x::Real, c::Frank)
+
+First derivative of the Frank copula inverse generator.
+"""
+function D¹φ⁻¹(x::Real, c::Frank)
     return (c.ϑ * exp(-c.ϑ * x)) / (exp(-c.ϑ * x) - 1)
 end
 

--- a/src/archimedean/frank.jl
+++ b/src/archimedean/frank.jl
@@ -27,6 +27,15 @@ function φ(x::Real, c::Frank)
 end
 
 """
+    φ⁻¹(x::Real, c::Frank)
+
+Inverse generator of the Frank copula.
+"""
+function φ⁻¹(x::Real, c::Frank)
+    return -log((exp(-c.ϑ * x) - 1) / (exp(-c.ϑ) - 1))
+end
+
+"""
     D¹φ(x::Real, c::Frank)
 
 First derivative of the Frank copula generator.
@@ -44,15 +53,6 @@ Second derivative of the Frank copula generator.
 function D²φ(x::Real, c::Frank)
     z = (1 - exp(-c.ϑ)) * exp(-x)
     return (1 / c.ϑ) * z / (1 - z)^2
-end
-
-"""
-    φ⁻¹(x::Real, c::Frank)
-
-Inverse generator of the Frank copula.
-"""
-function φ⁻¹(x::Real, c::Frank)
-    return -log((exp(-c.ϑ * x) - 1) / (exp(-c.ϑ) - 1))
 end
 
 """

--- a/src/archimedean/frank.jl
+++ b/src/archimedean/frank.jl
@@ -3,11 +3,14 @@ struct Frank <: ArchimedeanCopula
 
     function Frank(ϑ::Real)
         # bivariate frank is defined on ϑ ∈ (0, ∞)
-        @assert 0 <= ϑ < Inf
+        @assert 0 <= ϑ <= Inf
 
         if ϑ == 0.0
             @warn "Frank returns an independence copula for ϑ == 0.0"
             return Independence()
+        elseif ϑ == Inf
+            @warn "Frank returns an M copula for ϑ == Inf"
+            return M()
         end
 
         return new(ϑ)

--- a/src/archimedean/frank.jl
+++ b/src/archimedean/frank.jl
@@ -1,0 +1,55 @@
+struct Frank <: ArchimedeanCopula
+    ϑ::Real
+
+    function Frank(ϑ::Real)
+        # bivariate frank is defined on ϑ ∈ (0, ∞)
+        @assert 0 <= ϑ < Inf
+
+        if ϑ == 0.0
+            @warn "Frank returns an independence copula for ϑ == 0.0"
+            return Independence()
+        end
+
+        return new(ϑ)
+    end
+end
+
+function φ(x::Real, c::Frank)
+    return -1 / c.ϑ * log(exp(-x) * (exp(-c.ϑ) - 1) + 1)
+end
+
+function φ⁻¹(x::Real, c::Frank)
+    return -log((exp(-c.ϑ * x) - 1) / (exp(-c.ϑ) - 1))
+end
+
+function φ¹(x::Real, c::Frank)
+    z = (1 - exp(-c.ϑ)) * exp(-x)
+    return -(1 / c.ϑ) * z / (1 - z)
+end
+
+function φ²(x::Real, c::Frank)
+    z = (1 - exp(-c.ϑ)) * exp(-x)
+    return (1 / c.ϑ) * z / (1 - z)^2
+end
+
+function ∇φ⁻¹(x::Real, c::Frank)
+    return (c.ϑ * exp(-c.ϑ * x)) / (exp(-c.ϑ * x) - 1)
+end
+
+function sample(c::Frank, n::Int64)
+    @assert n > 0
+    E = rand(Exponential(1), (n, 2))
+
+    # Sample from the logarithmic distribution with α = 1 - exp(-ϑ)
+    # Kemp (1981) Efficient generation of logarithmically distributed pseudo-random variables
+    α = 1 - exp(-c.ϑ)
+    h = log(1 - α)
+    u = rand(n, 2)
+    M = trunc.(1 .+ log.(u[:, 2]) ./ log.(1 .- exp.(u[:, 1] .* h)))
+
+    return [φ.(E[:, 1] ./ M, c) φ.(E[:, 2] ./ M, c)]
+end
+
+function τ(c::Frank)
+    return 1 + 4 * (sf_debye_1(c.ϑ) - 1) / c.ϑ
+end

--- a/src/copulas.jl
+++ b/src/copulas.jl
@@ -565,11 +565,6 @@ W(M1::ContinuousUnivariateDistribution, M2::ContinuousUnivariateDistribution) = 
 function Pi(M1::ContinuousUnivariateDistribution, M2::ContinuousUnivariateDistribution)
     return Pi()(M1, M2)
 end
-function Frank(
-    M1::ContinuousUnivariateDistribution, M2::ContinuousUnivariateDistribution, s=1
-)
-    return Frank(s)(M1, M2)
-end
 function Gaussian(
     M1::ContinuousUnivariateDistribution, M2::ContinuousUnivariateDistribution, corr=0
 )

--- a/src/copulas.jl
+++ b/src/copulas.jl
@@ -195,7 +195,7 @@ function calcCdf(density::Array{<:Real,2})
     for i in 2:n
         for j in 2:n
             cdf[i, j] = (
-                density[i, j] / (n^2) + cdf[i, j - 1] + cdf[i - 1, j] - cdf[i - 1, j - 1]
+                density[i, j] / (n^2) + cdf[i, j-1] + cdf[i-1, j] - cdf[i-1, j-1]
             )
         end
     end
@@ -226,10 +226,10 @@ function calcDensity(
     yStep = Float64(yRange.step)
 
     density = zeros(size(cdf))
-    for i in 1:(n - 1)
-        for j in 1:(n - 1)
+    for i in 1:(n-1)
+        for j in 1:(n-1)
             density[i, j] =
-                (cdf[i, j] + cdf[i + 1, j + 1] - cdf[i + 1, j] - cdf[i, j + 1]) /
+                (cdf[i, j] + cdf[i+1, j+1] - cdf[i+1, j] - cdf[i, j+1]) /
                 (xStep * yStep)
 
             #   -> Possible alternative:
@@ -247,8 +247,8 @@ function calcDensity(
     #density[:,end] = reverse(density[1,:]);
 
     #   -> If joint, it may not be symetric
-    density[end, :] = density[end - 1, :]
-    density[:, end] = density[:, end - 1]
+    density[end, :] = density[end-1, :]
+    density[:, end] = density[:, end-1]
     return density
 end
 
@@ -709,7 +709,7 @@ end
 function linInterp(A, x)
     ind0 = findlast(A .<= x)
     x0 = A[ind0]
-    x1 = A[ind0 + 1]
+    x1 = A[ind0+1]
     y0 = ind0 / n
     y1 = (ind0 + 1) / n
 

--- a/src/copulas.jl
+++ b/src/copulas.jl
@@ -276,11 +276,6 @@ function Pi()
     return copula(indep(x, y); density=ones(n, n), func=indep)
 end
 
-function Frank(s=1)                                     #   Frank copula
-    x = y = range(0; stop=1, length=n)                          #   s>0; 0 for perfect, 1 for indep, inf for oposite
-    return copula(F(x, y, s); func=F, param=s)
-end
-
 function Gaussian(corr=0)
     x = y = range(0; stop=1, length=n)
     cdf = Gau(x, y, corr)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,5 @@
 [deps]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+HCubature = "19dc6840-f33b-545b-b366-655c7e3ffd49"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/archimedean/archimedean.jl
+++ b/test/archimedean/archimedean.jl
@@ -1,0 +1,31 @@
+copulas = [Clayton.([-0.75, 1])... Frank.([1.0, 10.0])...]
+
+@testset "Archimedean Copulas" begin
+
+    @testset "Generators" begin
+        u = range(0, 10, length=10)
+        for c in copulas
+            @test BivariateCopulas.φ⁻¹.(BivariateCopulas.φ.(u, c), c) ≈ u
+            @test BivariateCopulas.φ(0.0, c) ≈ 1.0
+
+            if isa(c, Clayton) && c.ϑ < 0 # not strict for ϑ < 0
+                @test BivariateCopulas.φ(floatmax(), c) == Inf
+                @test issorted(BivariateCopulas.φ.(u, c))
+            else
+                @test BivariateCopulas.φ(floatmax(), c) ≈ 0.0 atol = 1e-20
+                @test issorted(BivariateCopulas.φ.(u, c); rev=true)
+            end
+        end
+    end
+
+    @testset "Inverse Generators" begin
+        for c in copulas
+            if isa(c, Clayton) && c.ϑ < 0 # not strict for ϑ < 0
+                @test BivariateCopulas.φ⁻¹(0.0, c) == -1.0
+            else
+                @test BivariateCopulas.φ⁻¹(0.0, c) == Inf
+            end
+            @test BivariateCopulas.φ⁻¹(1.0, c) == 0.0
+        end
+    end
+end

--- a/test/archimedean/clayton.jl
+++ b/test/archimedean/clayton.jl
@@ -1,5 +1,5 @@
 n = 10^5
-θ = [-0.5, 2, 10]
+θ = [1, 2, 10]
 
 @testset "Clayton" begin
     @testset "constructor" begin
@@ -21,7 +21,7 @@ n = 10^5
     end
 
     @testset "τ" begin
-        @test τ(Clayton(θ[1])) == -1 / 3
+        @test τ(Clayton(θ[1])) == 1 / 3
         @test τ(Clayton(θ[2])) == 0.5
         @test τ(Clayton(θ[3])) == 10 / 12
     end
@@ -65,8 +65,6 @@ n = 10^5
 
         @test cdf.(Clayton(2), x, y) ≈
               [0.0, 0.1796053020267749, 0.37796447300922725, 0.6255432421712244, 1.0]
-        @test cdf.(Clayton(-0.5), x, y) ≈
-              [1.0, 0.0, 0.17157287525381, 0.5358983848622453, 1.0]
     end
 
     @testset "density" begin
@@ -76,7 +74,38 @@ n = 10^5
         @test isnan(BivariateCopulas.density(Clayton(2), x[1], y[1]))
         @test BivariateCopulas.density.(Clayton(2), x[2:end], y[2:end]) ≈
               [2.2965556205046926, 1.481003649342278, 1.614508582188617, 3.0]
+    end
 
-        @test BivariateCopulas.density.(Clayton(-0.5), x, y) ≈ [Inf, 2.0, 1.0, 2 / 3, 0.5]
+    @testset "grounded" begin
+        u = collect(range(0.0, 1.0, 10))
+        v = u
+        for ϑ in θ
+            c = Clayton(ϑ)
+            @test iszero(cdf.(c, u, 0.0))
+            @test iszero(cdf.(c, 0.0, v))
+        end
+    end
+
+    @testset "uniform margins" begin
+        u = collect(range(0.0, 1.0, 10))
+        v = u
+        for ϑ in θ
+            c = Clayton(ϑ)
+            @test cdf.(c, u, 1.0) ≈ u
+            @test cdf.(c, 1.0, v) ≈ v
+        end
+    end
+
+    @testset "2-increasing" begin
+        u = collect(range(0.0, 1.0, 10))
+        v = u
+        for ϑ in θ
+            c = Clayton(ϑ)
+            for i in 1:10
+                for j in i:10
+                    @test cdf(c, u[j], v[j]) - cdf(c, u[j], v[i]) - cdf(c, u[i], v[j]) + cdf(c, u[i], v[i]) >= 0.0
+                end
+            end
+        end
     end
 end

--- a/test/archimedean/clayton.jl
+++ b/test/archimedean/clayton.jl
@@ -1,9 +1,6 @@
 n = 10^5
 θ = [1, 2, 10]
 
-u = collect(range(0.0, 1.0, length=10))
-v = u
-
 @testset "Clayton" begin
     @testset "constructor" begin
         @test isa(Clayton(0), Independence)
@@ -16,6 +13,7 @@ v = u
     end
 
     @testset "generators" begin
+        u = range(0, 1, length=11)
         for ϑ in θ
             c = Clayton(ϑ)
             @test BivariateCopulas.φ⁻¹.(BivariateCopulas.φ.(u, c), c) ≈ u
@@ -81,6 +79,8 @@ v = u
     end
 
     @testset "groundedness" begin
+        u = range(0.0, 1.0, length=11)
+        v = u
         for ϑ in θ
             c = Clayton(ϑ)
             @test iszero(cdf.(c, u, 0.0))
@@ -89,6 +89,8 @@ v = u
     end
 
     @testset "uniform margins" begin
+        u = range(0.0, 1.0, length=11)
+        v = u
         for ϑ in θ
             c = Clayton(ϑ)
             @test cdf.(c, u, 1.0) ≈ u
@@ -97,10 +99,12 @@ v = u
     end
 
     @testset "2-increasing" begin
+        u = range(0.0, 1.0, length=101)
+        v = u
         for ϑ in θ
             c = Clayton(ϑ)
-            for i in 1:10
-                for j in i:10
+            for i in 1:100
+                for j in i:100
                     @test cdf(c, u[j], v[j]) - cdf(c, u[j], v[i]) - cdf(c, u[i], v[j]) + cdf(c, u[i], v[i]) >= 0.0
                 end
             end

--- a/test/archimedean/clayton.jl
+++ b/test/archimedean/clayton.jl
@@ -1,9 +1,6 @@
-n = 10^5
-θ = [-0.75, 1, 2]
-
 @testset "Clayton" begin
     @testset "constructor" begin
-        @test isa(Clayton(0), Independence)
+        @suppress @test isa(Clayton(0), Independence)
         @test_throws AssertionError Clayton(-2)
 
         @test_logs (:warn, "Clayton returns an independence copula for ϑ == 0.0") Clayton(
@@ -13,123 +10,10 @@ n = 10^5
         @test_logs (:warn, "Clayton returns a W copula for ϑ == -1") Clayton(-1)
     end
 
-    @testset "Generator" begin
-        u = range(0, 10, length=10)
-        for ϑ in θ
-            c = Clayton(ϑ)
-            @test BivariateCopulas.φ⁻¹.(BivariateCopulas.φ.(u, c), c) ≈ u
-            @test BivariateCopulas.φ(0.0, c) ≈ 1.0
-            if ϑ > 0
-                @test BivariateCopulas.φ(floatmax(), c) ≈ 0.0 atol = 1e-20
-            else # not strict for ϑ < 0
-                @test BivariateCopulas.φ(floatmax(), c) == Inf
-            end
-            if ϑ > 0
-                @test issorted(BivariateCopulas.φ.(u, c); rev=true)
-            else
-                @test issorted(BivariateCopulas.φ.(u, c))
-            end
-        end
-    end
-
-    @testset "Inverse Generator" begin
-        for ϑ in θ
-            c = Clayton(ϑ)
-            if ϑ > 0
-                @test BivariateCopulas.φ⁻¹(0.0, c) == Inf
-            else # not strict for ϑ < 0
-                @test BivariateCopulas.φ⁻¹(0.0, c) == -1.0
-            end
-            @test BivariateCopulas.φ⁻¹(1.0, c) == 0.0
-        end
-    end
-
     @testset "τ" begin
-        @test τ(Clayton(θ[1])) == -0.6
-        @test τ(Clayton(θ[2])) == 1 / 3
-        @test τ(Clayton(θ[3])) == 0.5
+        @test τ(Clayton(-0.75)) == -0.6
+        @test τ(Clayton(1)) == 1 / 3
+        @test τ(Clayton(2)) == 0.5
     end
 
-    @testset "sample" begin
-        for ϑ in θ
-            c = Clayton(ϑ)
-            u = BivariateCopulas.sample(c, n)
-            @test corkendall(u) ≈ [1.0 τ(c); τ(c) 1.0] atol = 0.01
-        end
-    end
-
-    @testset "rosenblatt" begin
-        for ϑ in θ
-            c = Clayton(ϑ)
-            u = BivariateCopulas.sample(c, n)
-            @test corkendall(rosenblatt(u, c)) ≈ [1.0 0.0; 0.0 1.0] atol = 0.01
-        end
-    end
-
-    @testset "inverse_rosenblatt" begin
-        for ϑ in θ
-            c = Clayton(ϑ)
-            u = BivariateCopulas.sample(c, n)
-
-            @test inverse_rosenblatt(rosenblatt(u, c), c) ≈ u
-        end
-    end
-
-    @testset "sklar's theorem" begin
-        c = Clayton(2)
-        X = Normal()
-        Y = Normal()
-
-        @test isa(c(X, Y), Joint)
-    end
-
-    @testset "cdf" begin
-        x = [0:0.25:1;]
-        y = x
-
-        @test cdf.(Clayton(2), x, y) ≈
-              [0.0, 0.1796053020267749, 0.37796447300922725, 0.6255432421712244, 1.0]
-    end
-
-    @testset "density" begin
-        x = [0:0.25:1;]
-        y = x
-
-        @test isnan(BivariateCopulas.density(Clayton(2), x[1], y[1]))
-        @test BivariateCopulas.density.(Clayton(2), x[2:end], y[2:end]) ≈
-              [2.2965556205046926, 1.481003649342278, 1.614508582188617, 3.0]
-    end
-
-    @testset "groundedness" begin
-        u = range(0.0, 1.0, length=11)
-        v = u
-        for ϑ in θ
-            c = Clayton(ϑ)
-            @test iszero(cdf.(c, u, 0.0))
-            @test iszero(cdf.(c, 0.0, v))
-        end
-    end
-
-    @testset "uniform margins" begin
-        u = range(0.0, 1.0, length=11)
-        v = u
-        for ϑ in θ
-            c = Clayton(ϑ)
-            @test cdf.(c, u, 1.0) ≈ u
-            @test cdf.(c, 1.0, v) ≈ v
-        end
-    end
-
-    @testset "2-increasing" begin
-        u = range(0.0, 1.0, length=101)
-        v = u
-        for ϑ in θ
-            c = Clayton(ϑ)
-            for i in 1:100
-                for j in i:100
-                    @test cdf(c, u[j], v[j]) - cdf(c, u[j], v[i]) - cdf(c, u[i], v[j]) + cdf(c, u[i], v[i]) >= 0.0
-                end
-            end
-        end
-    end
 end

--- a/test/archimedean/clayton.jl
+++ b/test/archimedean/clayton.jl
@@ -1,6 +1,9 @@
 n = 10^5
 θ = [1, 2, 10]
 
+u = collect(range(0.0, 1.0, length=10))
+v = u
+
 @testset "Clayton" begin
     @testset "constructor" begin
         @test isa(Clayton(0), Independence)
@@ -77,8 +80,6 @@ n = 10^5
     end
 
     @testset "grounded" begin
-        u = collect(range(0.0, 1.0, 10))
-        v = u
         for ϑ in θ
             c = Clayton(ϑ)
             @test iszero(cdf.(c, u, 0.0))
@@ -87,8 +88,6 @@ n = 10^5
     end
 
     @testset "uniform margins" begin
-        u = collect(range(0.0, 1.0, 10))
-        v = u
         for ϑ in θ
             c = Clayton(ϑ)
             @test cdf.(c, u, 1.0) ≈ u
@@ -97,8 +96,6 @@ n = 10^5
     end
 
     @testset "2-increasing" begin
-        u = collect(range(0.0, 1.0, 10))
-        v = u
         for ϑ in θ
             c = Clayton(ϑ)
             for i in 1:10

--- a/test/archimedean/clayton.jl
+++ b/test/archimedean/clayton.jl
@@ -16,10 +16,11 @@ v = u
     end
 
     @testset "generators" begin
-        u = [0:0.1:1;]
         for ϑ in θ
             c = Clayton(ϑ)
             @test BivariateCopulas.φ⁻¹.(BivariateCopulas.φ.(u, c), c) ≈ u
+            @test BivariateCopulas.φ(0.0, c) ≈ 1.0
+            @test BivariateCopulas.φ(floatmax(), c) ≈ 0.0 atol = 1e-20
         end
     end
 
@@ -79,7 +80,7 @@ v = u
               [2.2965556205046926, 1.481003649342278, 1.614508582188617, 3.0]
     end
 
-    @testset "grounded" begin
+    @testset "groundedness" begin
         for ϑ in θ
             c = Clayton(ϑ)
             @test iszero(cdf.(c, u, 0.0))

--- a/test/archimedean/clayton.jl
+++ b/test/archimedean/clayton.jl
@@ -1,4 +1,4 @@
-n = 10^6
+n = 10^5
 θ = [-0.5, 2, 10]
 
 @testset "Clayton" begin
@@ -6,7 +6,6 @@ n = 10^6
         @test isa(Clayton(0), Independence)
         @test_throws AssertionError Clayton(-2)
 
-        @test_logs (:warn, "Clayton returns a W copula for ϑ < -0.5") Clayton(-0.7)
         @test_logs (:warn, "Clayton returns an independence copula for ϑ == 0.0") Clayton(
             0.0
         )
@@ -65,9 +64,9 @@ n = 10^6
         y = x
 
         @test cdf.(Clayton(2), x, y) ≈
-            [0.0, 0.1796053020267749, 0.37796447300922725, 0.6255432421712244, 1.0]
+              [0.0, 0.1796053020267749, 0.37796447300922725, 0.6255432421712244, 1.0]
         @test cdf.(Clayton(-0.5), x, y) ≈
-            [1.0, 0.0, 0.17157287525381, 0.5358983848622453, 1.0]
+              [1.0, 0.0, 0.17157287525381, 0.5358983848622453, 1.0]
     end
 
     @testset "density" begin
@@ -76,7 +75,7 @@ n = 10^6
 
         @test isnan(BivariateCopulas.density(Clayton(2), x[1], y[1]))
         @test BivariateCopulas.density.(Clayton(2), x[2:end], y[2:end]) ≈
-            [2.2965556205046926, 1.481003649342278, 1.614508582188617, 3.0]
+              [2.2965556205046926, 1.481003649342278, 1.614508582188617, 3.0]
 
         @test BivariateCopulas.density.(Clayton(-0.5), x, y) ≈ [Inf, 2.0, 1.0, 2 / 3, 0.5]
     end

--- a/test/archimedean/frank.jl
+++ b/test/archimedean/frank.jl
@@ -1,9 +1,6 @@
 n = 10^5
 θ = [1.0, 10.0, 20.0]
 
-u = collect(range(0.0, 1.0, length=10))
-v = u
-
 @testset "Frank" begin
     @testset "constructor" begin
         @test isa(Frank(0), Independence)
@@ -16,7 +13,7 @@ v = u
     end
 
     @testset "generators" begin
-        u = [0:0.1:1;]
+        u = range(0, 1, length=10)
         c = Frank(10.0)
         @test BivariateCopulas.φ⁻¹.(BivariateCopulas.φ.(u, c), c) ≈ u
         @test BivariateCopulas.φ(0.0, c) ≈ 1.0
@@ -80,6 +77,8 @@ v = u
     end
 
     @testset "groundedness" begin
+        u = range(0.0, 1.0, length=11)
+        v = u
         for ϑ in θ
             c = Frank(ϑ)
             @test iszero(cdf.(c, u, 0.0))
@@ -88,6 +87,8 @@ v = u
     end
 
     @testset "uniform margins" begin
+        u = range(0.0, 1.0, length=11)
+        v = u
         for ϑ in θ
             c = Frank(ϑ)
             @test cdf.(c, u, 1.0) ≈ u
@@ -96,10 +97,12 @@ v = u
     end
 
     @testset "2-increasing" begin
+        u = range(0.0, 1.0, length=101)
+        v = u
         for ϑ in θ
             c = Frank(ϑ)
-            for i in 1:10
-                for j in i:10
+            for i in 1:100
+                for j in i:100
                     @test cdf(c, u[j], v[j]) - cdf(c, u[j], v[i]) - cdf(c, u[i], v[j]) + cdf(c, u[i], v[i]) >= 0.0
                 end
             end

--- a/test/archimedean/frank.jl
+++ b/test/archimedean/frank.jl
@@ -6,18 +6,21 @@ v = u
 
 @testset "Frank" begin
     @testset "constructor" begin
-        @test_throws AssertionError Frank(Inf)
         @test isa(Frank(0), Independence)
+        @test_throws AssertionError Frank(-2.0)
 
         @test_logs (:warn, "Frank returns an independence copula for ϑ == 0.0") Frank(
             0.0
         )
+        @test_logs (:warn, "Frank returns an M copula for ϑ == Inf") Frank(Inf)
     end
 
     @testset "generators" begin
         u = [0:0.1:1;]
         c = Frank(10.0)
         @test BivariateCopulas.φ⁻¹.(BivariateCopulas.φ.(u, c), c) ≈ u
+        @test BivariateCopulas.φ(0.0, c) ≈ 1.0
+        @test BivariateCopulas.φ(floatmax(), c) ≈ 0.0 atol = 1e-20
     end
 
     @testset "τ" begin
@@ -76,7 +79,7 @@ v = u
               [1.127276244650801, 1.0207470412683992, 1.1272762446508016, 1.5819767068693265]
     end
 
-    @testset "grounded" begin
+    @testset "groundedness" begin
         for ϑ in θ
             c = Frank(ϑ)
             @test iszero(cdf.(c, u, 0.0))

--- a/test/archimedean/frank.jl
+++ b/test/archimedean/frank.jl
@@ -12,12 +12,23 @@ n = 10^5
         @test_logs (:warn, "Frank returns an M copula for ϑ == Inf") Frank(Inf)
     end
 
-    @testset "generators" begin
-        u = range(0, 1, length=10)
-        c = Frank(10.0)
-        @test BivariateCopulas.φ⁻¹.(BivariateCopulas.φ.(u, c), c) ≈ u
-        @test BivariateCopulas.φ(0.0, c) ≈ 1.0
-        @test BivariateCopulas.φ(floatmax(), c) ≈ 0.0 atol = 1e-20
+    @testset "Generator" begin
+        u = range(0, 10, length=10)
+        for ϑ in θ
+            c = Frank(ϑ)
+            @test BivariateCopulas.φ⁻¹.(BivariateCopulas.φ.(u, c), c) ≈ u
+            @test BivariateCopulas.φ(0.0, c) ≈ 1.0
+            @test BivariateCopulas.φ(floatmax(), c) ≈ 0.0 atol = 1e-20
+            @test issorted(BivariateCopulas.φ.(u, c); rev=true)
+        end
+    end
+
+    @testset "Inverse Generator" begin
+        for ϑ in θ
+            c = Frank(ϑ)
+            @test BivariateCopulas.φ⁻¹(0.0, c) == Inf
+            @test BivariateCopulas.φ⁻¹(1.0, c) == 0.0
+        end
     end
 
     @testset "τ" begin

--- a/test/archimedean/frank.jl
+++ b/test/archimedean/frank.jl
@@ -1,0 +1,74 @@
+n = 10^5
+
+@testset "Frank" begin
+    @testset "constructor" begin
+        @test_throws AssertionError Frank(Inf)
+        @test isa(Frank(0), Independence)
+
+        @test_logs (:warn, "Frank returns an independence copula for ϑ == 0.0") Frank(
+            0.0
+        )
+    end
+
+    @testset "generators" begin
+        u = [0:0.1:1;]
+        c = Frank(10.0)
+        @test BivariateCopulas.φ⁻¹.(BivariateCopulas.φ.(u, c), c) ≈ u
+    end
+
+    @testset "τ" begin
+        @test τ(Frank(1.0)) == 0.11001853644899295
+        @test τ(Frank(10.0)) == 0.6657773862719785
+        @test τ(Frank(20.0)) == 0.81644934023564
+    end
+
+    @testset "sample" begin
+        c = Frank(10.0)
+        u = BivariateCopulas.sample(c, n)
+        @test corkendall(u) ≈ [1.0 τ(c); τ(c) 1.0] atol = 0.01
+    end
+
+    @testset "rosenblatt" begin
+        c = Frank(20.0)
+        u = BivariateCopulas.sample(c, n)
+        @test corkendall(rosenblatt(u, c)) ≈ [1.0 0.0; 0.0 1.0] atol = 0.01
+    end
+
+    @testset "inverse_rosenblatt" begin
+        c = Frank(1.0)
+        u = BivariateCopulas.sample(c, n)
+
+        @test inverse_rosenblatt(rosenblatt(u, c), c) ≈ u
+    end
+
+    @testset "sklar's theorem" begin
+        c = Frank(1.0)
+        X = Normal()
+        Y = Normal()
+
+        @test isa(c(X, Y), Joint)
+    end
+
+    @testset "cdf" begin
+        x = [0:0.25:1;]
+        y = x
+
+        @test cdf.(Frank(10.0), x, y) ≈
+              [0.0, 0.18490043593650232, 0.4313568167929175, 0.6849004359365126, 0.9999999999999871]
+        @test cdf.(Frank(1.0), x, y) ≈
+              [0.0, 0.08056458733770672, 0.28092980362016146, 0.580564587337707, 1.0]
+    end
+
+    @testset "density" begin
+        x = [0:0.25:1;]
+        y = x
+
+        @test isnan(BivariateCopulas.density.(Frank(10.0), x[1], y[1]))
+        @test BivariateCopulas.density.(Frank(10.0), x[2:end], y[2:end]) ≈
+              [2.720019944137354, 2.533918274531531, 2.7200199441379125, 10.000454019907506]
+
+        @test isnan(BivariateCopulas.density.(Frank(1.0), x[1], y[1]))
+        @test BivariateCopulas.density.(Frank(1.0), x[2:end], y[2:end]) ≈
+              [1.127276244650801, 1.0207470412683992, 1.1272762446508016, 1.5819767068693265]
+    end
+end

--- a/test/archimedean/frank.jl
+++ b/test/archimedean/frank.jl
@@ -1,6 +1,9 @@
 n = 10^5
 θ = [1.0, 10.0, 20.0]
 
+u = collect(range(0.0, 1.0, length=10))
+v = u
+
 @testset "Frank" begin
     @testset "constructor" begin
         @test_throws AssertionError Frank(Inf)
@@ -74,8 +77,6 @@ n = 10^5
     end
 
     @testset "grounded" begin
-        u = collect(range(0.0, 1.0, 10))
-        v = u
         for ϑ in θ
             c = Frank(ϑ)
             @test iszero(cdf.(c, u, 0.0))
@@ -84,8 +85,6 @@ n = 10^5
     end
 
     @testset "uniform margins" begin
-        u = collect(range(0.0, 1.0, 10))
-        v = u
         for ϑ in θ
             c = Frank(ϑ)
             @test cdf.(c, u, 1.0) ≈ u
@@ -94,8 +93,6 @@ n = 10^5
     end
 
     @testset "2-increasing" begin
-        u = collect(range(0.0, 1.0, 10))
-        v = u
         for ϑ in θ
             c = Frank(ϑ)
             for i in 1:10

--- a/test/archimedean/frank.jl
+++ b/test/archimedean/frank.jl
@@ -1,4 +1,5 @@
 n = 10^5
+θ = [1.0, 10.0, 20.0]
 
 @testset "Frank" begin
     @testset "constructor" begin
@@ -70,5 +71,38 @@ n = 10^5
         @test isnan(BivariateCopulas.density.(Frank(1.0), x[1], y[1]))
         @test BivariateCopulas.density.(Frank(1.0), x[2:end], y[2:end]) ≈
               [1.127276244650801, 1.0207470412683992, 1.1272762446508016, 1.5819767068693265]
+    end
+
+    @testset "grounded" begin
+        u = collect(range(0.0, 1.0, 10))
+        v = u
+        for ϑ in θ
+            c = Frank(ϑ)
+            @test iszero(cdf.(c, u, 0.0))
+            @test iszero(cdf.(c, 0.0, v))
+        end
+    end
+
+    @testset "uniform margins" begin
+        u = collect(range(0.0, 1.0, 10))
+        v = u
+        for ϑ in θ
+            c = Frank(ϑ)
+            @test cdf.(c, u, 1.0) ≈ u
+            @test cdf.(c, 1.0, v) ≈ v
+        end
+    end
+
+    @testset "2-increasing" begin
+        u = collect(range(0.0, 1.0, 10))
+        v = u
+        for ϑ in θ
+            c = Frank(ϑ)
+            for i in 1:10
+                for j in i:10
+                    @test cdf(c, u[j], v[j]) - cdf(c, u[j], v[i]) - cdf(c, u[i], v[j]) + cdf(c, u[i], v[i]) >= 0.0
+                end
+            end
+        end
     end
 end

--- a/test/archimedean/frank.jl
+++ b/test/archimedean/frank.jl
@@ -1,9 +1,6 @@
-n = 10^5
-θ = [1.0, 10.0, 20.0]
-
 @testset "Frank" begin
     @testset "constructor" begin
-        @test isa(Frank(0), Independence)
+        @suppress @test isa(Frank(0), Independence)
         @test_throws AssertionError Frank(-2.0)
 
         @test_logs (:warn, "Frank returns an independence copula for ϑ == 0.0") Frank(
@@ -11,112 +8,10 @@ n = 10^5
         )
         @test_logs (:warn, "Frank returns an M copula for ϑ == Inf") Frank(Inf)
     end
-
-    @testset "Generator" begin
-        u = range(0, 10, length=10)
-        for ϑ in θ
-            c = Frank(ϑ)
-            @test BivariateCopulas.φ⁻¹.(BivariateCopulas.φ.(u, c), c) ≈ u
-            @test BivariateCopulas.φ(0.0, c) ≈ 1.0
-            @test BivariateCopulas.φ(floatmax(), c) ≈ 0.0 atol = 1e-20
-            @test issorted(BivariateCopulas.φ.(u, c); rev=true)
-        end
-    end
-
-    @testset "Inverse Generator" begin
-        for ϑ in θ
-            c = Frank(ϑ)
-            @test BivariateCopulas.φ⁻¹(0.0, c) == Inf
-            @test BivariateCopulas.φ⁻¹(1.0, c) == 0.0
-        end
-    end
-
     @testset "τ" begin
         @test τ(Frank(1.0)) == 0.11001853644899295
         @test τ(Frank(10.0)) == 0.6657773862719785
         @test τ(Frank(20.0)) == 0.81644934023564
     end
 
-    @testset "sample" begin
-        c = Frank(10.0)
-        u = BivariateCopulas.sample(c, n)
-        @test corkendall(u) ≈ [1.0 τ(c); τ(c) 1.0] atol = 0.01
-    end
-
-    @testset "rosenblatt" begin
-        c = Frank(20.0)
-        u = BivariateCopulas.sample(c, n)
-        @test corkendall(rosenblatt(u, c)) ≈ [1.0 0.0; 0.0 1.0] atol = 0.01
-    end
-
-    @testset "inverse_rosenblatt" begin
-        c = Frank(1.0)
-        u = BivariateCopulas.sample(c, n)
-
-        @test inverse_rosenblatt(rosenblatt(u, c), c) ≈ u
-    end
-
-    @testset "sklar's theorem" begin
-        c = Frank(1.0)
-        X = Normal()
-        Y = Normal()
-
-        @test isa(c(X, Y), Joint)
-    end
-
-    @testset "cdf" begin
-        x = [0:0.25:1;]
-        y = x
-
-        @test cdf.(Frank(10.0), x, y) ≈
-              [0.0, 0.18490043593650232, 0.4313568167929175, 0.6849004359365126, 0.9999999999999871]
-        @test cdf.(Frank(1.0), x, y) ≈
-              [0.0, 0.08056458733770672, 0.28092980362016146, 0.580564587337707, 1.0]
-    end
-
-    @testset "density" begin
-        x = [0:0.25:1;]
-        y = x
-
-        @test isnan(BivariateCopulas.density.(Frank(10.0), x[1], y[1]))
-        @test BivariateCopulas.density.(Frank(10.0), x[2:end], y[2:end]) ≈
-              [2.720019944137354, 2.533918274531531, 2.7200199441379125, 10.000454019907506]
-
-        @test isnan(BivariateCopulas.density.(Frank(1.0), x[1], y[1]))
-        @test BivariateCopulas.density.(Frank(1.0), x[2:end], y[2:end]) ≈
-              [1.127276244650801, 1.0207470412683992, 1.1272762446508016, 1.5819767068693265]
-    end
-
-    @testset "groundedness" begin
-        u = range(0.0, 1.0, length=11)
-        v = u
-        for ϑ in θ
-            c = Frank(ϑ)
-            @test iszero(cdf.(c, u, 0.0))
-            @test iszero(cdf.(c, 0.0, v))
-        end
-    end
-
-    @testset "uniform margins" begin
-        u = range(0.0, 1.0, length=11)
-        v = u
-        for ϑ in θ
-            c = Frank(ϑ)
-            @test cdf.(c, u, 1.0) ≈ u
-            @test cdf.(c, 1.0, v) ≈ v
-        end
-    end
-
-    @testset "2-increasing" begin
-        u = range(0.0, 1.0, length=101)
-        v = u
-        for ϑ in θ
-            c = Frank(ϑ)
-            for i in 1:100
-                for j in i:100
-                    @test cdf(c, u[j], v[j]) - cdf(c, u[j], v[i]) - cdf(c, u[i], v[j]) + cdf(c, u[i], v[i]) >= 0.0
-                end
-            end
-        end
-    end
 end

--- a/test/copulas.jl
+++ b/test/copulas.jl
@@ -1,0 +1,83 @@
+copulas = [Clayton.([-0.75, 2])... Frank.([1, 10])...]
+n = 10^5
+
+@testset "Copulas" begin
+    @testset "grounded" begin
+        u = range(0.0, 1.0, length=10)
+        v = u
+        for c in copulas
+            @test iszero(cdf.(c, u, 0.0))
+            @test iszero(cdf.(c, 0.0, v))
+        end
+    end
+
+    @testset "uniform margins" begin
+        u = range(0.0, 1.0, length=10)
+        v = u
+        for c in copulas
+            @test cdf.(c, u, 1.0) ≈ u
+            @test cdf.(c, 1.0, v) ≈ v
+        end
+    end
+
+    @testset "2-increasing" begin
+        u = range(0.0, 1.0, length=100)
+        v = u
+        for c in copulas
+            for i in 1:100
+                for j in i:100
+                    @test cdf(c, u[j], v[j]) - cdf(c, u[j], v[i]) - cdf(c, u[i], v[j]) + cdf(c, u[i], v[i]) >= 0.0
+                end
+            end
+        end
+    end
+
+    @testset "sample" begin
+        for c in copulas
+            u = BivariateCopulas.sample(c, n)
+            @test corkendall(u) ≈ [1.0 τ(c); τ(c) 1.0] atol = 0.01
+        end
+    end
+
+    @testset "sklar's theorem" begin
+        X = Normal()
+        Y = Normal()
+
+        for c in copulas
+            @test isa(c(X, Y), Joint)
+        end
+    end
+
+    @testset "rosenblatt" begin
+        for c in copulas
+            u = BivariateCopulas.sample(c, n)
+            @test corkendall(rosenblatt(u, c)) ≈ [1.0 0.0; 0.0 1.0] atol = 0.01
+        end
+    end
+
+    @testset "inverse rosenblatt" begin
+        for c in copulas
+            u = BivariateCopulas.sample(c, n)
+
+            @test inverse_rosenblatt(rosenblatt(u, c), c) ≈ u
+        end
+    end
+
+    @testset "density" begin
+        for c in copulas
+
+            if isa(c, Clayton) && c.ϑ < 0 # takes too long to converge otherwise
+                0.95 <= hcubature(x -> density(c, x[1], x[2]), zeros(2), ones(2); maxevals=10^6)[1] <= 1.05
+                continue
+            end
+            A = hcubature(x -> density(c, x[1], x[2]), zeros(2), ones(2))
+            @test A[1] ≈ 1.0 atol = A[2]
+
+            x = range(0, 1; length=10)
+            y = range(0, 1; length=10)
+            for xᵢ in x, yᵢ in y
+                @test density(c, xᵢ, yᵢ) >= 0
+            end
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,11 @@
 using BivariateCopulas
+using HCubature
 using StatsBase
+using Suppressor
 using Test
 
+include("archimedean/archimedean.jl")
 include("archimedean/clayton.jl")
 include("archimedean/frank.jl")
+
+include("copulas.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,3 +3,4 @@ using StatsBase
 using Test
 
 include("archimedean/clayton.jl")
+include("archimedean/frank.jl")


### PR DESCRIPTION
This PR will add the *Frank* copula in line with the previously defined interface for archimedean copulas. It also fixes some issues there were with the *Clayton* copula.  I changed the naming conventions for the derivatives to make them easier to read and write.

I removed the extension of the *Clayton* copula to negative parameters. According to Dependence modeling with copulas (Harry Joe) the extension to negative dependence is not supported in all of [0,1]^d and therefore not useful for statistical modeling. While sampling would work as is, the `cdf` and `density` functions aren't well defined for negative dependence. Thoughts?

Also adds tests for groundedness, uniform margins and 2-increasingness as well as a few tests for generator limits.

New dependencies are `GSL` for the `debye` function and `Roots`. Since there is no closed form solution for the inverse rosenblatt for archimedean copulas other than `Clayton` I am using root finding to invert the transformation. This can be quite slow for large sample sizes.